### PR TITLE
Update libspatialite and its dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ INCLUDEDIR = ${PREFIX}/include
 
 CXX = ${XCODE_DEVELOPER}/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++
 CC = ${XCODE_DEVELOPER}/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
-CFLAGS = -isysroot ${IOS_SDK} -I${IOS_SDK}/usr/include -arch ${ARCH} -I${INCLUDEDIR} -miphoneos-version-min=7.0
-CXXFLAGS = -stdlib=libc++ -std=c++11 -isysroot ${IOS_SDK} -I${IOS_SDK}/usr/include -arch ${ARCH} -I${INCLUDEDIR} -miphoneos-version-min=7.0
+CFLAGS = -isysroot ${IOS_SDK} -I${IOS_SDK}/usr/include -arch ${ARCH} -I${INCLUDEDIR} -miphoneos-version-min=7.0 -O3
+CXXFLAGS = -stdlib=libc++ -std=c++11 -isysroot ${IOS_SDK} -I${IOS_SDK}/usr/include -arch ${ARCH} -I${INCLUDEDIR} -miphoneos-version-min=7.0 -O3
 LDFLAGS = -stdlib=libc++ -isysroot ${IOS_SDK} -L${LIBDIR} -L${IOS_SDK}/usr/lib -arch ${ARCH} -miphoneos-version-min=7.0
 
 arch: ${LIBDIR}/libspatialite.a
@@ -55,13 +55,13 @@ ${LIBDIR}/libspatialite.a: ${LIBDIR}/libproj.a ${LIBDIR}/libgeos.a ${LIBDIR}/lib
 	CC=${CC} \
 	CFLAGS="${CFLAGS} -Wno-error=implicit-function-declaration" \
 	CXXFLAGS="${CXXFLAGS} -Wno-error=implicit-function-declaration" \
-	LDFLAGS="${LDFLAGS} -liconv -lgeos -lgeos_c -lc++" ./configure --host=${HOST} --disable-freexl --prefix=${PREFIX} --with-geosconfig=${BINDIR}/geos-config --disable-shared && make clean install-strip
+	LDFLAGS="${LDFLAGS} -liconv -lgeos -lgeos_c -lc++" ./configure --host=${HOST} --enable-freexl=no --enable-libxml2=no --prefix=${PREFIX} --with-geosconfig=${BINDIR}/geos-config --disable-shared && make clean install-strip
 
 ${CURDIR}/spatialite:
-	curl http://www.gaia-gis.it/gaia-sins/libspatialite-sources/libspatialite-4.3.0.tar.gz > spatialite.tar.gz
+	curl http://www.gaia-gis.it/gaia-sins/libspatialite-sources/libspatialite-4.3.0a.tar.gz > spatialite.tar.gz
 	tar -xzf spatialite.tar.gz
 	rm spatialite.tar.gz
-	mv libspatialite-4.3.0 spatialite
+	mv libspatialite-4.3.0a spatialite
 	patch -Np0 < spatialite.patch
 
 ${LIBDIR}/libproj.a: ${CURDIR}/proj
@@ -73,10 +73,10 @@ ${LIBDIR}/libproj.a: ${CURDIR}/proj
 	LDFLAGS="${LDFLAGS}" ./configure --host=${HOST} --prefix=${PREFIX} --disable-shared && make clean install
 
 ${CURDIR}/proj:
-	curl -L https://github.com/OSGeo/proj.4/archive/4.8.0.tar.gz > proj.tar.gz
+	curl -L http://download.osgeo.org/proj/proj-4.9.3.tar.gz > proj.tar.gz
 	tar -xzf proj.tar.gz
 	rm proj.tar.gz
-	mv proj.4-4.8.0 proj
+	mv proj-4.9.3 proj
 
 ${LIBDIR}/libgeos.a: ${CURDIR}/geos
 	cd geos && env \
@@ -87,10 +87,10 @@ ${LIBDIR}/libgeos.a: ${CURDIR}/geos
 	LDFLAGS="${LDFLAGS}" ./configure --host=${HOST} --prefix=${PREFIX} --disable-shared && make clean install
 
 ${CURDIR}/geos:
-	curl http://download.osgeo.org/geos/geos-3.4.2.tar.bz2 > geos.tar.bz2
+	curl http://download.osgeo.org/geos/geos-3.6.1.tar.bz2 > geos.tar.bz2
 	tar -xzf geos.tar.bz2
 	rm geos.tar.bz2
-	mv geos-3.4.2 geos
+	mv geos-3.6.1 geos
 
 ${LIBDIR}/libsqlite3.a: ${CURDIR}/sqlite3
 	cd sqlite3 && env LIBTOOL=${XCODE_DEVELOPER}/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool \
@@ -102,10 +102,10 @@ ${LIBDIR}/libsqlite3.a: ${CURDIR}/sqlite3
 	./configure --host=${HOST} --prefix=${PREFIX} --disable-shared --enable-static && make clean install
 
 ${CURDIR}/sqlite3:
-	curl http://sqlite.org/2015/sqlite-autoconf-3081100.tar.gz > sqlite3.tar.gz
+	curl http://www.sqlite.org/2017/sqlite-autoconf-3170000.tar.gz > sqlite3.tar.gz
 	tar xzvf sqlite3.tar.gz
 	rm sqlite3.tar.gz
-	mv sqlite-autoconf-3081100 sqlite3
+	mv sqlite-autoconf-3170000 sqlite3
 	touch sqlite3
 
 clean:


### PR DESCRIPTION
Update libspatialite and its dependencies to the versions detailed on the libspatialite MinGW-w64 build guide (http://www.gaia-gis.it/gaia-sins/mingw64_how_to.html).

Add -O3 since the libspatialite author uses that optimization level in the build guide for MinGW, and because speed/space savings are important on iOS.

Change libspatialite configure parameters to match the new requirement: libxml2 is enabled by default.